### PR TITLE
update firmware install path

### DIFF
--- a/romulus-firmware-extract.sh
+++ b/romulus-firmware-extract.sh
@@ -5,7 +5,7 @@ set -u  # Treat unset variables as an error
 set -o pipefail  # Catch errors in pipelines
 
 # Define paths
-device_path="microsoft/Romulus"
+device_path="microsoft/"
 firmware_dir="/lib/firmware/updates/qcom/x1e80100/${device_path}"
 tmp_dir="/tmp/surface_fw_extract"
 msi_file="${tmp_dir}/SurfaceLaptop7_ARM_Win11.msi"


### PR DESCRIPTION
This error message when booting indicated the path the GPU driver was looking for: 

[    4.363291] adreno 3d00000.gpu: [drm:zap_shader_load_mdt [msm]] *ERROR* Unable to load qcom/x1e80100/microsoft/qcdxkmsuc8380.mbn

I moved all my firmware into this path assuming it was the correct thing to do. 