### PR TITLE
Subsystem-device number

### DIFF
--- a/fix-board-2-wifi.sh
+++ b/fix-board-2-wifi.sh
@@ -5,11 +5,6 @@ FW_URL="https://git.codelinaro.org/clo/ath-firmware/ath12k-firmware/-/raw/main/W
 BDENCODER_URL="https://raw.githubusercontent.com/qca/qca-swiss-army-knife/master/tools/scripts/ath12k/ath12k-bdencoder"
 FW_DIR="/lib/firmware/ath12k/WCN7850/hw2.0"
 
-# The entry in the JSON above where we are going to insert
-MATCH_NAME="bus=pci,vendor=17cb,device=1107,subsystem-vendor=17cb,subsystem-device=3378,qmi-chip-id=2,qmi-board-id=255"
-# The entry to insert
-NEW_DEVICE_STRING="bus=pci,vendor=17cb,device=1107,subsystem-vendor=17cb,subsystem-device=XXXX,qmi-chip-id=2,qmi-board-id=255"
-
 tmp=$(mktemp -d)
 cleanup() {
   popd >/dev/null || true
@@ -35,7 +30,7 @@ import json
 import sys
 
 match_name = "bus=pci,vendor=17cb,device=1107,subsystem-vendor=17cb,subsystem-device=3378,qmi-chip-id=2,qmi-board-id=255"
-new_name = "bus=pci,vendor=17cb,device=1107,subsystem-vendor=17cb,subsystem-device=XXXX,qmi-chip-id=2,qmi-board-id=255"
+new_name = "bus=pci,vendor=17cb,device=1107,subsystem-vendor=17cb,subsystem-device=1107,qmi-chip-id=2,qmi-board-id=255"
 
 with open("board-2.json", "r", encoding="utf-8") as f:
     data = json.load(f)

--- a/patches/0003-fix-duplicate-battery.patch
+++ b/patches/0003-fix-duplicate-battery.patch
@@ -1,0 +1,46 @@
+--- a/drivers/power/supply/surface_battery.c
++++ b/drivers/power/supply/surface_battery.c
+@@ -11,6 +11,7 @@
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/mutex.h>
++#include <linux/of.h>
+ #include <linux/power_supply.h>
+ #include <linux/sysfs.h>
+ #include <linux/types.h>
+@@ -817,6 +818,12 @@
+ static int surface_battery_probe(struct ssam_device *sdev)
+ {
+ 	const struct spwr_psy_properties *p;
++
++	/* On Surface Laptop 7 ARM, battery is managed by qcom_battmgr. */
++	if (of_machine_is_compatible("microsoft,romulus13") ||
++	    of_machine_is_compatible("microsoft,romulus15"))
++		return -ENODEV;
++
+ 	struct spwr_battery_device *bat;
+ 
+ 	p = ssam_device_get_match_data(sdev);
+--- a/drivers/power/supply/surface_charger.c
++++ b/drivers/power/supply/surface_charger.c
+@@ -10,6 +10,7 @@
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/mutex.h>
++#include <linux/of.h>
+ #include <linux/power_supply.h>
+ #include <linux/types.h>
+ 
+@@ -231,6 +232,12 @@
+ static int surface_ac_probe(struct ssam_device *sdev)
+ {
+ 	const struct spwr_psy_properties *p;
++
++	/* On Surface Laptop 7 ARM, charging is managed by qcom_battmgr. */
++	if (of_machine_is_compatible("microsoft,romulus13") ||
++	    of_machine_is_compatible("microsoft,romulus15"))
++		return -ENODEV;
++
+ 	struct spwr_ac_device *ac;
+ 
+ 	p = ssam_device_get_match_data(sdev);


### PR DESCRIPTION
Fix up from the other day - turns out subsystem-device is always 1107 for SL7, this simplifies the script and makes it 100% plug & play for the user.